### PR TITLE
Add options to always check query parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
 before_script:
   - wget http://getcomposer.org/composer.phar
   - php composer.phar install --dev
+  - phpenv config-rm xdebug.ini
 
 script:
   - bin/coke

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ fost_rest:
 m6_web_fos_rest_extra:
     extra_query_parameters:
 
-        # Enable check of query parameters on all actions with or without dedicated annotation
+        # Enable check of extra query parameters on all actions with or without dedicated annotation
         # Optionnal, false by default
         always_check: true
 

--- a/README.md
+++ b/README.md
@@ -32,13 +32,27 @@ new FOS\RestBundle\FOSRestBundle(),
 new M6Web\Bundle\FOSRestExtraBundle\M6WebFOSRestExtraBundle(),
 ```
 
-## Configuration
 
-Modify the FOSRestBundle configuration of your application to add :
+Then modify the FOSRestBundle configuration of your application to add :
 
 ```yaml
 fost_rest:
     param_fetcher_listener: true
+```
+
+## Configuration
+
+```yml
+m6_web_fos_rest_extra:
+    extra_query_parameters:
+
+        # Enable check of query parameters on all actions with or without dedicated annotation
+        # Optionnal, false by default
+        always_check: true
+
+        # HTTP status code of throwed exception on query with non allowed extra parameters
+        # Optionnal, 400 by default
+        http_code: 403
 ```
 
 ## Usage

--- a/src/FOSRestExtraBundle/DependencyInjection/Configuration.php
+++ b/src/FOSRestExtraBundle/DependencyInjection/Configuration.php
@@ -15,7 +15,21 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('m6_web_fos_rest_extra');
+        $rootNode = $treeBuilder->root('m6_web_fos_rest_extra');
+
+        $rootNode
+            ->children()
+                ->arrayNode('extra_query_parameters')
+                    ->children()
+                        ->scalarNode('always_check')
+                            ->defaultFalse()
+                        ->end()
+                        ->scalarNode('http_code')
+                            ->defaultValue(400)
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
 
         return $treeBuilder;
     }

--- a/src/FOSRestExtraBundle/DependencyInjection/M6WebFOSRestExtraExtension.php
+++ b/src/FOSRestExtraBundle/DependencyInjection/M6WebFOSRestExtraExtension.php
@@ -16,11 +16,29 @@ class M6WebFOSRestExtraExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $configuration = new Configuration();
-        $this->processConfiguration($configuration, $configs);
-
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
+
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        if (!empty($config['extra_query_parameters'])) {
+            $paramFetcherListener = $container->getDefinition('m6_web_fos_rest_extra.listener.param_fetcher.listener');
+
+            if (isset($config['extra_query_parameters']['always_check'])) {
+                $paramFetcherListener->addMethodCall(
+                    'alwaysCheckRequestParameters',
+                    [$config['extra_query_parameters']['always_check']]
+                );
+            }
+
+            if (isset($config['extra_query_parameters']['http_code'])) {
+                $paramFetcherListener->addMethodCall(
+                    'setErrorCode',
+                    [$config['extra_query_parameters']['http_code']]
+                );
+            }
+        }
     }
 
     /**

--- a/src/FOSRestExtraBundle/EventListener/ParamFetcherListener.php
+++ b/src/FOSRestExtraBundle/EventListener/ParamFetcherListener.php
@@ -76,11 +76,11 @@ class ParamFetcherListener
      *
      * @param FilterControllerEvent $event
      *
-     * @throws \InvalidArgumentException
+     * @throws HttpException
      */
     public function onKernelController(FilterControllerEvent $event)
     {
-        if ($this->isCheckRequired($event)) {
+        if ($event->isMasterRequest() && $this->isCheckRequired($event)) {
             $request = $event->getRequest();
 
             // Check difference between the paramFetcher and the request

--- a/src/FOSRestExtraBundle/Resources/config/services.yml
+++ b/src/FOSRestExtraBundle/Resources/config/services.yml
@@ -2,7 +2,7 @@ parameters:
     param_fetcher_listener.class: M6Web\Bundle\FOSRestExtraBundle\EventListener\ParamFetcherListener
 
 services:
-    kernel.listener.param_fetcher:
+    m6_web_fos_rest_extra.listener.param_fetcher.listener:
         class: "%param_fetcher_listener.class%"
         arguments: [@annotation_reader, @fos_rest.request.param_fetcher]
         scope: request

--- a/src/FOSRestExtraBundle/Tests/Units/EventListener/ParamFetcherListener.php
+++ b/src/FOSRestExtraBundle/Tests/Units/EventListener/ParamFetcherListener.php
@@ -41,6 +41,25 @@ class ParamFetcherListener extends atoum\test
                 )
                     ->isInstanceOf('Symfony\Component\HttpKernel\Exception\HttpException')
                     ->hasMessage("Invalid parameters 'test2' for route 'get_test'")
+                ->integer($this->exception->getStatusCode())
+                    ->isEqualTo(400)
+        ;
+
+        $this
+            ->if($base = $this->getBase(['test' => null], true))
+            ->and($base->alwaysCheckRequestParameters(true))
+            ->and($base->setErrorCode(401))
+            ->and($event = $this->getFilterControllerEvent('getNonRestrictedAction', ['test' => 'toto', 'test2' => 1]))
+            ->then
+                ->exception(
+                    function() use($base, $event) {
+                        $base->onKernelController($event);
+                    }
+                )
+                    ->isInstanceOf('Symfony\Component\HttpKernel\Exception\HttpException')
+                    ->hasMessage("Invalid parameters 'test2' for route 'get_test'")
+                ->integer($this->exception->getStatusCode())
+                    ->isEqualTo(401)
         ;
     }
 

--- a/src/FOSRestExtraBundle/Tests/Units/EventListener/ParamFetcherListener.php
+++ b/src/FOSRestExtraBundle/Tests/Units/EventListener/ParamFetcherListener.php
@@ -121,6 +121,7 @@ class ParamFetcherListener extends atoum\test
 
         // Generate Event
         $event = new \mock\Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+        $event->getMockController()->isMasterRequest = true;
         $event->getMockController()->getRequest = $request;
         $event->getMockController()->getController = [
             'M6Web\Bundle\FOSRestExtraBundle\Tests\Units\EventListener\TestController',


### PR DESCRIPTION
This PR add an option to check extra parameters for all actions. It also makes the HTTP status code of the thrown exception configurable.