### PR TITLE
Add strict option + config refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 fos-rest-extra-bundle
 =======================
 
-Extra features for the FOSRestBundle
+Provide extra feature for the [FOSRestBundle](https://github.com/FriendsOfSymfony/FOSRestBundle).
 
 ## Dependency
 
@@ -44,20 +44,26 @@ fost_rest:
 
 ```yml
 m6_web_fos_rest_extra:
-    extra_query_parameters:
+    param_fetcher:
 
-        # Enable check of extra query parameters on all actions with or without dedicated annotation
+        # Define if extra parameters are allowed. The behavior defined here is the default one and can
+        # be overrided by a "RestrictExtraParam" annotation on the current action.
+        # Optionnal, true by default
+        allow_extra: true
+
+        # Define if all parameters are strict. If true, all given parameters have to match defined
+        # format for each on of them.
         # Optionnal, false by default
-        always_check: true
+        strict: false
 
-        # HTTP status code of throwed exception on query with non allowed extra parameters
+        # HTTP status code of throwed exception on query with invalid parameters
         # Optionnal, 400 by default
-        http_code: 403
+        error_status_code: 400
 ```
 
 ## Usage
 
-- RestrictExtraParam Annotation : to forbid unknown parameters
+- `RestrictExtraParam(true/false)` Annotation : to allow (`false`) or forbid (`true`) unknown parameters, `true` by default.
 
 ```php
 
@@ -74,7 +80,7 @@ class TestController
      *
      * @return void
      *
-     * @RestrictExtraParam()
+     * @RestrictExtraParam(true)
      *
      * @QueryParam(name="param1", requirements="\d+", nullable=true, description="My Param 1")
      */
@@ -84,6 +90,7 @@ class TestController
 
     /**
      * Unrestricted controller : "param1" and unknown parameters are permitted
+     * except if bundle configuration doesn't allow it
      *
      * @QueryParam(name="param1", requirements="\d+", nullable=true, description="My Param 1")
      *

--- a/src/FOSRestExtraBundle/Annotation/RestrictExtraParam.php
+++ b/src/FOSRestExtraBundle/Annotation/RestrictExtraParam.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace M6Web\Bundle\FOSRestExtraBundle\Annotation;
 
 /**
@@ -10,5 +9,5 @@ namespace M6Web\Bundle\FOSRestExtraBundle\Annotation;
  */
 class RestrictExtraParam
 {
-
+    public $value = true;
 }

--- a/src/FOSRestExtraBundle/DependencyInjection/Configuration.php
+++ b/src/FOSRestExtraBundle/DependencyInjection/Configuration.php
@@ -19,12 +19,15 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->arrayNode('extra_query_parameters')
+                ->arrayNode('param_fetcher')
                     ->children()
-                        ->scalarNode('always_check')
+                        ->scalarNode('allow_extra')
+                            ->defaultTrue()
+                        ->end()
+                        ->scalarNode('strict')
                             ->defaultFalse()
                         ->end()
-                        ->scalarNode('http_code')
+                        ->scalarNode('error_status_code')
                             ->defaultValue(400)
                         ->end()
                     ->end()

--- a/src/FOSRestExtraBundle/DependencyInjection/M6WebFOSRestExtraExtension.php
+++ b/src/FOSRestExtraBundle/DependencyInjection/M6WebFOSRestExtraExtension.php
@@ -22,21 +22,21 @@ class M6WebFOSRestExtraExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        if (!empty($config['extra_query_parameters'])) {
-            $paramFetcherListener = $container->getDefinition('m6_web_fos_rest_extra.listener.param_fetcher.listener');
+        if (!empty($config['param_fetcher'])) {
 
-            if (isset($config['extra_query_parameters']['always_check'])) {
-                $paramFetcherListener->addMethodCall(
-                    'alwaysCheckRequestParameters',
-                    [$config['extra_query_parameters']['always_check']]
-                );
-            }
+            $paramFetcherListener = $container
+                ->getDefinition('m6_web_fos_rest_extra.listener.param_fetcher.listener');
 
-            if (isset($config['extra_query_parameters']['http_code'])) {
-                $paramFetcherListener->addMethodCall(
-                    'setErrorCode',
-                    [$config['extra_query_parameters']['http_code']]
-                );
+            $configMap = [
+                'allow_extra'       => 'setAllowExtraParam',
+                'strict'            => 'setStrict',
+                'error_status_code' => 'setErrorCode',
+            ];
+
+            foreach ($configMap as $key => $method) {
+                if (isset($config['param_fetcher'][$key])) {
+                    $paramFetcherListener->addMethodCall($method, [$config['param_fetcher'][$key]]);
+                }
             }
         }
     }

--- a/src/FOSRestExtraBundle/Tests/Units/EventListener/TestController.php
+++ b/src/FOSRestExtraBundle/Tests/Units/EventListener/TestController.php
@@ -1,31 +1,24 @@
 <?php
-
 namespace M6Web\Bundle\FOSRestExtraBundle\Tests\Units\EventListener;
 
 use M6Web\Bundle\FOSRestExtraBundle\Annotation\RestrictExtraParam;
 
-/**
- * TestController
- */
 class TestController
 {
     /**
-     * Test controller
-     *
-     * @return void
-     *
-     * @RestrictExtraParam()
+     * @RestrictExtraParam(true)
      */
-    public function getRestrictedAction() {
-
-    }
+    public function getRestrictedTrueAction() {}
 
     /**
-     * Test controller
-     *
-     * @return void
+     * @RestrictExtraParam(false)
      */
-    public function getNonRestrictedAction() {
+    public function getRestrictedFalseAction() {}
 
-    }
+    /**
+     * @RestrictExtraParam()
+     */
+    public function getRestrictedDefaultAction() {}
+
+    public function getNonRestrictedAction() {}
 }


### PR DESCRIPTION
close #4 
* Add an option to define all query parameters as strict.
* Config refactoring.

New configuration example :
```yml
m6_web_fos_rest_extra:
    param_fetcher:
        allow_extra: false
        strict: true
        error_status_code: 400
```