### PR TITLE
Fix configuration

### DIFF
--- a/src/FOSRestExtraBundle/Resources/config/services.yml
+++ b/src/FOSRestExtraBundle/Resources/config/services.yml
@@ -5,6 +5,5 @@ services:
     m6_web_fos_rest_extra.listener.param_fetcher.listener:
         class: "%param_fetcher_listener.class%"
         arguments: ["@annotation_reader", "@fos_rest.request.param_fetcher"]
-        scope: request
         tags:
             - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }


### PR DESCRIPTION
Because since SF 2.8, `scopes` are [deprecated](https://symfony.com/doc/2.8/service_container/scopes.html) and this message appear : ` The configuration key "scope" is unsupported for definition "m6_web_fos_rest_extra.listener.param_fetcher.listener"`

