### PR TITLE
make listener compliant with php8

### DIFF
--- a/src/FOSRestExtraBundle/EventListener/ParamFetcherListener.php
+++ b/src/FOSRestExtraBundle/EventListener/ParamFetcherListener.php
@@ -136,8 +136,9 @@ class ParamFetcherListener
     {
         $controller = $event->getController();
 
-        if (is_callable($controller) && method_exists($controller, '__invoke')) {
-            $controller = array($controller, '__invoke');
+        $name = '__invoke';
+        if (is_object($controller) && is_callable($controller)) {
+            $controller = [$controller, $name];
         }
 
         if (is_array($controller)) {

--- a/src/FOSRestExtraBundle/EventListener/ParamFetcherListener.php
+++ b/src/FOSRestExtraBundle/EventListener/ParamFetcherListener.php
@@ -136,9 +136,8 @@ class ParamFetcherListener
     {
         $controller = $event->getController();
 
-        $name = '__invoke';
         if (is_object($controller) && is_callable($controller)) {
-            $controller = [$controller, $name];
+            $controller = [$controller, '__invoke'];
         }
 
         if (is_array($controller)) {


### PR DESCRIPTION
## Why
In PHP8 `method_exists` and `ReflectionMethod` no longer support array as first parameter

## How
Use `is_callable` to replace `method_exists`