### PR TITLE
feat: update newer version FOSRestBundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['7.4', '8.0']
+                php-versions: ['7.4', '8.1']
         steps:
             - uses: actions/checkout@v2
             - uses: shivammathur/setup-php@v2

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ test: atoum
 .PHONY: clean-vendor
 clean-vendor:
 	$(call printSection,DEPENDENCIES clean)
+	rm -f ${SOURCE_DIR}/composer.lock
 	rm -rf ${SOURCE_DIR}/vendor
 
 .PHONY: composer-install
@@ -43,7 +44,7 @@ ${SOURCE_DIR}/vendor/composer/installed.json:
 .PHONY: atoum
 atoum:
 	$(call printSection,TEST atoum)
-	${BIN_DIR}/atoum
+	XDEBUG_MODE=coverage ${BIN_DIR}/atoum
 
 ### QUALITY ###
 

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,15 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.4|^8.0",
-        "friendsofsymfony/rest-bundle"   : "~1.1||^2.0",
+        "friendsofsymfony/rest-bundle" : "^3.3",
+        "symfony/config": "^5.4|^6.0",
+        "symfony/dependency-injection": "^5.4|^6.0",
+        "symfony/http-foundation": "^5.4|^6.0",
         "doctrine/common": "@stable"
     },
     "require-dev": {
-        "atoum/atoum"       : "^4.0",
+        "atoum/atoum"              : "^4.0",
         "m6web/php-cs-fixer-config": "2.0.*",
-        "phpstan/phpstan": "0.12.*"
+        "phpstan/phpstan"          : "^1.8"
     }
 }

--- a/src/FOSRestExtraBundle/DependencyInjection/Configuration.php
+++ b/src/FOSRestExtraBundle/DependencyInjection/Configuration.php
@@ -15,8 +15,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('m6_web_fos_rest_extra');
+        $treeBuilder = new TreeBuilder('m6_web_fos_rest_extra');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/FOSRestExtraBundle/DependencyInjection/M6WebFOSRestExtraExtension.php
+++ b/src/FOSRestExtraBundle/DependencyInjection/M6WebFOSRestExtraExtension.php
@@ -43,14 +43,7 @@ class M6WebFOSRestExtraExtension extends Extension
         }
     }
 
-    /**
-     * (non-PHPdoc)
-     *
-     * @see \Symfony\Component\DependencyInjection\Extension\Extension::getAlias()
-     *
-     * @return string
-     */
-    public function getAlias()
+    public function getAlias(): string
     {
         return 'm6_web_fos_rest_extra';
     }

--- a/src/FOSRestExtraBundle/Tests/Units/EventListener/TestController.php
+++ b/src/FOSRestExtraBundle/Tests/Units/EventListener/TestController.php
@@ -9,25 +9,25 @@ class TestController
     /**
      * @RestrictExtraParam(true)
      */
-    public function getRestrictedTrueAction()
+    public static function getRestrictedTrueAction()
     {
     }
 
     /**
      * @RestrictExtraParam(false)
      */
-    public function getRestrictedFalseAction()
+    public static function getRestrictedFalseAction()
     {
     }
 
     /**
      * @RestrictExtraParam()
      */
-    public function getRestrictedDefaultAction()
+    public static function getRestrictedDefaultAction()
     {
     }
 
-    public function getNonRestrictedAction()
+    public static function getNonRestrictedAction()
     {
     }
 }


### PR DESCRIPTION
Adding compatibility with the latest version of `friendsofsymfony/rest-bundle:3.3` 
This bundle will be no more compatible with `1.1` and `2.0` versions of `friendsofsymfony/rest-bundle`